### PR TITLE
fix: change tsc to babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@babel/generator": "^7.11.6",
     "@babel/parser": "^7.11.5",
     "@babel/traverse": "^7.11.5",
+    "@babel/types": "^7.11.5",
     "@types/json5": "^0.0.30",
     "@types/node": "^14.11.2",
     "commander": "^6.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
+    "@babel/generator": "^7.11.6",
+    "@babel/parser": "^7.11.5",
+    "@babel/traverse": "^7.11.5",
     "@types/json5": "^0.0.30",
     "@types/node": "^14.11.2",
     "commander": "^6.1.0",

--- a/src/modules/ast/astParser/astParser.test.ts
+++ b/src/modules/ast/astParser/astParser.test.ts
@@ -1,37 +1,33 @@
-import { join } from "path"
-import { fileReader } from "../../file/fileReader/fileReader"
-import { astParser } from "./astParser"
+import { join } from "path";
+import { fileReader } from "../../file/fileReader/fileReader";
+import { astParser } from "./astParser";
 
-// astの中身自体については, tsc の管轄内であり, test を書くコストを考えて今一旦はそれを信じここでは source の入力に対してSourceFileの出力が帰ってくることだけを✅したい
+// astの中身自体については, @babel/parser の管轄内であり, test を書くコストを考えて今一旦はそれを信じここでは source の入力に対してASTの出力が帰ってくることだけを✅したい
 
 describe("astParser", () => {
-    test("astParser ts", () => {
-        const source = fileReader(join(__dirname, "./source.ts"))
+  test("astParser ts", () => {
+    const ast = (() => {
+      try {
+        astParser(join(__dirname, "./source.ts"));
+        return "ok";
+      } catch {
+        return "err";
+      }
+    })();
 
-        const ast = (() => {
-            try {
-                astParser(source);
-                return "ok"
-            }catch{
-                return "err"
-            }
-        })()
+    expect(ast).toBe("ok");
+  });
 
-        expect(ast).toBe("ok")
-    })
+  test("astParser tsx", () => {
+    const ast = (() => {
+      try {
+        astParser(join(__dirname, "./source.ts"));
+        return "ok";
+      } catch {
+        return "err";
+      }
+    })();
 
-    test("astParser tsx", () => {
-        const source = fileReader(join(__dirname, "./source.tsx"))
-
-        const ast = (() => {
-            try {
-                astParser(source);
-                return "ok"
-            }catch{
-                return "err"
-            }
-        })()
-
-        expect(ast).toBe("ok")
-    })
-})
+    expect(ast).toBe("ok");
+  });
+});

--- a/src/modules/ast/astParser/astParser.ts
+++ b/src/modules/ast/astParser/astParser.ts
@@ -1,13 +1,12 @@
-import * as tsc from "typescript";
+import { parse } from "@babel/parser";
+import { join } from "path";
+import { fileReader } from "../../file/fileReader/fileReader";
 
-export const astParser = (entry: string, config: tsc.CompilerOptions) => {
-  const program = tsc.createProgram([entry], config);
-  const sources = program.getSourceFiles();
-  // TODO is this right way to find SourceFile object of entry file .ts ?
-  const source = sources.find(sourceEl => sourceEl.fileName.substr(-5) !== ".d.ts");
-  if(!source) {
-    throw new Error("astParser: source is undefined")
-  }
+export const astParser = (entry: string) => {
+  const source = fileReader(entry);
 
-  return source
+  return parse(source, {
+    sourceType: "module",
+    plugins: ["jsx"],
+  });
 };

--- a/src/modules/ast/codegen/codegen.ts
+++ b/src/modules/ast/codegen/codegen.ts
@@ -1,7 +1,7 @@
-import * as tsc from "typescript";
-import { fileWriter } from "../../file/fileWriter/fileWriter";
+import { File } from "@babel/types";
+import generate from "@babel/generator";
 
-export const codegen = (source: tsc.SourceFile, printer: tsc.Printer, dist: string) => {
-    const outputSource =  printer.printFile(source);
-    return fileWriter(outputSource, dist);
-}
+export const codegen = (ast: File) => {
+  const { code } = generate(ast);
+  return code;
+};

--- a/src/modules/ast/convertTsx2TemplateLiteral/convertTsxToString/convertTsxToString.ts
+++ b/src/modules/ast/convertTsx2TemplateLiteral/convertTsxToString/convertTsxToString.ts
@@ -1,25 +1,6 @@
-import * as tsc from "typescript";
+import { NodePath } from "@babel/traverse";
+import { JSXElement } from "@babel/types"
 
-type f = (
-  source: tsc.SourceFile
-) => (
-  context: tsc.TransformationContext
-) => (rootNode: tsc.SourceFile) => tsc.SourceFile;
+//TODO later
 
-export const convertTsxToString: f = (source) => {
-  return (context) => {
-    return (rootNode) => {
-      function visitor(node: tsc.Node): tsc.Node {
-        if (tsc.isJsxElement(node)) {
-          const stringJsx = node.getFullText(source);
-
-          return tsc.createStringLiteral(stringJsx);
-        }
-
-        return tsc.visitEachChild(node, visitor, context);
-      }
-
-      return tsc.visitEachChild(rootNode, visitor, context);
-    };
-  };
-};
+export const convertTsxToString = (nodePath: NodePath<JSXElement>) => {};


### PR DESCRIPTION
## WHY

To lead more usability, I would like to this compiler as a babel plugin.
So I use babel instead of typescript compiler to handle AST