### PR TITLE
refactor: resolvePath

### DIFF
--- a/packages/jsx2templateLiteral/src/modules/file/resolvePath/from.ts
+++ b/packages/jsx2templateLiteral/src/modules/file/resolvePath/from.ts
@@ -1,0 +1,1 @@
+// should be empty

--- a/packages/jsx2templateLiteral/src/modules/file/resolvePath/resolvePath.test.ts
+++ b/packages/jsx2templateLiteral/src/modules/file/resolvePath/resolvePath.test.ts
@@ -1,0 +1,25 @@
+import { existsSync } from "fs";
+import { join } from "path";
+import { resolvePath } from "./resolvePath";
+
+const abs = join(__dirname, "./from.ts");
+
+describe("resolvePath", () => {
+  test("abs/from.ts -> ./to.ts", () => {
+    expect(existsSync(resolvePath(abs, "./to.ts"))).toBeTruthy();
+  });
+
+  test("abs/from.ts -> to.ts", () => {
+    expect(existsSync(resolvePath(abs, "to.ts"))).toBeTruthy();
+  });
+
+  test("abs/from.ts -> ./to", () => {
+    expect(existsSync(resolvePath(abs, "./to"))).toBeTruthy();
+  });
+
+  test("abs/from.ts -> ../../../../package.json", () => {
+    expect(
+      existsSync(resolvePath(abs, "../../../../package.json"))
+    ).toBeTruthy();
+  });
+});

--- a/packages/jsx2templateLiteral/src/modules/file/resolvePath/resolvePath.ts
+++ b/packages/jsx2templateLiteral/src/modules/file/resolvePath/resolvePath.ts
@@ -4,7 +4,7 @@ import { resolve } from "path";
 const supportedFile = [".ts", ".js", ".tsx", ".jsx", ".json"];
 
 export const resolvePath = (absPath: string, rel: string) => {
-  const basePath = !isAbsolutePathIncludesFileExtension(absPath)
+  const basePath = isAbsolutePathIncludesFileExtension(absPath)
     ? absPath.split("/").slice(0, -1).join("/")
     : absPath;
 
@@ -25,6 +25,6 @@ export const resolvePath = (absPath: string, rel: string) => {
 
 const isAbsolutePathIncludesFileExtension = (absPath: string) => {
   return supportedFile.some((file) => {
-    return file === absPath.slice(-1 * file.length - 1);
+    return file === absPath.slice(-1 * file.length);
   });
 };

--- a/packages/jsx2templateLiteral/src/modules/file/resolvePath/to.ts
+++ b/packages/jsx2templateLiteral/src/modules/file/resolvePath/to.ts
@@ -1,0 +1,1 @@
+// should be empty


### PR DESCRIPTION
## WHY

- there is no tests
- this module could resolve only `.tsx`
- if `absPath` refers to dir, process will fail