### PR TITLE
fix: replacement return statement on traverse is fired in twice

### DIFF
--- a/packages/jsx2templateLiteral/src/modules/ast/convertTsx2TemplateLiteral/convertTsx2TemplateLiteral.tsx
+++ b/packages/jsx2templateLiteral/src/modules/ast/convertTsx2TemplateLiteral/convertTsx2TemplateLiteral.tsx
@@ -23,6 +23,7 @@ export const convertTsx2TemplateLiteral = (ast: File, target: string) => {
   traverse(ast, {
     ReturnStatement(nodePath) {
       convertReturnedJSXElementToString(nodePath);
+      nodePath.skip();
     },
   });
 };


### PR DESCRIPTION
https://github.com/babel/babel/issues/4956
https://twitter.com/sebmck/status/1132038207309172736

babel/traverse retraverse when node#replaceWith is called