### PR TITLE
feat: add error message to show lit-jsx doesn't support JSXNamespacedName

### DIFF
--- a/packages/jsx2templateLiteral/src/modules/ast/convertTsx2TemplateLiteral/getPropsKey/getPropsKey.ts
+++ b/packages/jsx2templateLiteral/src/modules/ast/convertTsx2TemplateLiteral/getPropsKey/getPropsKey.ts
@@ -1,13 +1,17 @@
 import { NodePath } from "@babel/traverse";
-import { JSXAttribute } from "@babel/types";
+import {
+  isJSXIdentifier,
+  isJSXNamespacedName,
+  JSXAttribute,
+} from "@babel/types";
 
-export const getPropsKey = (attr: NodePath<JSXAttribute>) => {
-  const key = attr.node.name.name;
-  // TODO why key can be JSXIdentifier ?
+export const getPropsKey = (attrNode: NodePath<JSXAttribute>) => {
+  const attr = attrNode.node.name;
 
-  if (typeof key !== "string") {
-    throw new Error("key is JSXIdentifier, invalid type");
+  if (isJSXIdentifier(attr)) {
+    return attr.name;
   }
 
-  return key;
+  // JSXNamespacedName
+  throw new Error("lit-jsx doesn't support namespaced attribute key");
 };


### PR DESCRIPTION
## WHY

I decided not to support JSXNamespacedName props, because lit-jsx handle JSXAttributes as object property, and JSXNamespacedName including `:` is not inappriciate for object property