### PR TITLE
Update: traverse order

### DIFF
--- a/packages/lit-jsx-core/visitor/convertTsx2TemplateLiteral/convertTsx2TemplateLiteral.tsx
+++ b/packages/lit-jsx-core/visitor/convertTsx2TemplateLiteral/convertTsx2TemplateLiteral.tsx
@@ -20,12 +20,17 @@ export const convertTsx2TemplateLiteral = (ast: File, target: string) => {
     //     compileEachFile(importedJsxPath);
     //   }
     // },
-  });
 
-  traverse(ast, {
     ReturnStatement(nodePath) {
       convertReturnedJSXElementToString(nodePath);
-      nodePath.skip();
+      // nodePath.skip();
     },
   });
+
+  // traverse(ast, {
+  //   ReturnStatement(nodePath) {
+  //     convertReturnedJSXElementToString(nodePath);
+  //     nodePath.skip();
+  //   },
+  // });
 };

--- a/packages/lit-jsx-core/visitor/visitor.ts
+++ b/packages/lit-jsx-core/visitor/visitor.ts
@@ -19,7 +19,6 @@ export const visitor: TraverseOptions = {
   //   },
   ReturnStatement(nodePath) {
     convertReturnedJSXElementToString(nodePath);
-    nodePath.skip();
   },
 };
 


### PR DESCRIPTION
## Problems

in traverse process, `ReturnStatement` and `JSXElement` is executed at the same time.

## Solution

this is not the problem that `babel/traverse` don't have ordering option, but deps